### PR TITLE
Update AHAS Sentinel HPA metric adapter

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,7 @@
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
-  digest = "1:fe34286169fb13fad456ef0ab4deb473d291e252b7716eb5c6888480955bfae7"
+  digest = "1:8d072343887cf9fbc668f8abc0f806db3d6e010bbcd554221f00e6db44e632b2"
   name = "github.com/aliyun/alibaba-cloud-sdk-go"
   packages = [
     "sdk",
@@ -43,7 +43,7 @@
     "services/cms",
   ]
   pruneopts = "UT"
-  revision = "7f3f78098e60423174ebfd887318a1624ff0b319"
+  revision = "e12a36812fc2913bde902039b9a5ebeba6c012a6"
 
 [[projects]]
   digest = "1:d2bcba229754e28dabd8eb793a56227d4784d6e985ee8d26aa6059c47b383549"
@@ -1068,6 +1068,8 @@
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/client-go/dynamic",
+    "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/rest",
     "k8s.io/component-base/logs",
     "k8s.io/klog",
     "k8s.io/metrics/pkg/apis/custom_metrics",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -41,7 +41,7 @@
   name = "github.com/aliyun/aliyun-log-go-sdk"
 
 [[constraint]]
-   revision = "7f3f78098e60423174ebfd887318a1624ff0b319"
+   revision = "e12a36812fc2913bde902039b9a5ebeba6c012a6"
    name = "github.com/aliyun/alibaba-cloud-sdk-go"
 
 [[constraint]]

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Events:
 * <a href="docs/metrics/sls.md">Ingress（SLS)</a>
 * <a href="docs/metrics/slb.md">SLB</a>
 * <a href="docs/metrics/cms.md">CMS</a>
+* <a href="docs/metrics/ahas_sentinel.md">AHAS Sentinel</a>
 
 
 ### Contributing 

--- a/docs/metrics/ahas_sentinel.md
+++ b/docs/metrics/ahas_sentinel.md
@@ -61,6 +61,7 @@ spec:
       labels:
         name: agent-foo-on-pilot
       annotations:
+        ahasPilotAutoEnable: "on"
         ahasAppName: "foo-service-on-pilot"
         ahasNamespace: "default"
     spec:
@@ -106,10 +107,11 @@ spec:
     - port: 80
       targetPort: 8700
   selector:
-    name: foo-service
+    name: agent-foo-on-pilot
   type: LoadBalancer
   externalTrafficPolicy: Local
 ---
+# To make the HPA enabled, we need to also install the AHAS Sentinel pilot helm chart in ACK console.
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -118,19 +120,18 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1beta2
     kind: Deployment
-    name: foo-service
+    name: agent-foo-on-pilot
   minReplicas: 1
   maxReplicas: 3
   metrics:
     - type: External
       external:
         metric:
-          name: agent-foo-on-pilot
+          name: ahas_sentinel_total_qps
           selector:
             matchLabels:
             # If you're using AHAS Sentinel pilot, then the appName and namespace
-            # can be retrieved from the annotation pf target Deployment automatically.
-
+            # can be retrieved from the annotation of target Deployment automatically.
             # ahas.sentinel.app: "foo-service-on-pilot"
             # ahas.sentinel.namespace: "default"
         target:

--- a/examples/ahas-sentinel.yaml
+++ b/examples/ahas-sentinel.yaml
@@ -33,6 +33,7 @@ spec:
       labels:
         name: agent-foo-on-pilot
       annotations:
+        ahasPilotAutoEnable: "on"
         ahasAppName: "foo-service-on-pilot"
         ahasNamespace: "default"
     spec:
@@ -78,7 +79,7 @@ spec:
     - port: 80
       targetPort: 8700
   selector:
-    name: foo-service
+    name: agent-foo-on-pilot
   type: LoadBalancer
   externalTrafficPolicy: Local
 ---
@@ -91,19 +92,18 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1beta2
     kind: Deployment
-    name: foo-service
+    name: agent-foo-on-pilot
   minReplicas: 1
   maxReplicas: 3
   metrics:
     - type: External
       external:
         metric:
-          name: agent-foo-on-pilot
+          name: ahas_sentinel_total_qps
           selector:
             matchLabels:
             # If you're using AHAS Sentinel pilot, then the appName and namespace
-            # can be retrieved from the annotation pf target Deployment automatically.
-
+            # can be retrieved from the annotation of target Deployment automatically.
             # ahas.sentinel.app: "foo-service-on-pilot"
             # ahas.sentinel.namespace: "default"
         target:

--- a/examples/ahas-sentinel.yaml
+++ b/examples/ahas-sentinel.yaml
@@ -1,31 +1,3 @@
-## AHAS Sentinel External metrics
-
-#### Global Params
-
-All metrics need the global params.
-
-| Global params       | Description              | Example            | Required | Default value |
-| ------------------- | ------------------------ | ------------------ | -------- | ------------- | 
-| `ahas.sentinel.app` | The name of your service in AHAS | sentinel-console | True |  |
-| `ahas.sentinel.namespace` | The namespace of your service in AHAS | staging | False | default |
-| `ahas.sentinel.interval` | The query interval of request count (in second) | 5 | False | 10 |
-
-Note that the `ahas.sentinel.app` is required, which should match the `project.name` property configured in AHAS Sentinel.
-
-#### Metrics List
-
-| metric name                  | description                               | extra params |
-| ---------------------------- | ----------------------------------------- | ------------ |
-| ahas_sentinel_total_qps             | total QPS                       | None         |
-| ahas_sentinel_pass_qps             | passed QPS                       | None         |
-| ahas_sentinel_block_qps              | blocked QPS (i.e. rejected by Sentinel)      | None         |
-| ahas_sentinel_avg_rt              | average response time              | None         |
-
-#### Example
-
-To make the HPA enabled, please also [install the AHAS Sentinel pilot helm chart in ACK console](https://cs.console.aliyun.com/#/k8s/catalog/detail/incubator_ack-ahas-sentinel-pilot).
-
-```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -110,6 +82,7 @@ spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
 ---
+# To make the HPA enabled, we need to also install the AHAS Sentinel pilot helm chart in ACK console.
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -137,4 +110,3 @@ spec:
           type: Value
           # ahas_sentinel_total_qps > 30
           value: 30
-```

--- a/pkg/metrics/ahas/ahas_sentinel_test.go
+++ b/pkg/metrics/ahas/ahas_sentinel_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestInvalidGetAhasSentinelParams(t *testing.T) {
 	r := make([]labels.Requirement, 0)
-	_, e := getAhasSentinelParams(r)
+	_, e := getAhasSentinelParams(r, "")
 	if e != nil {
 		t.Log("pass TestInvalidGetAhasSentinelParams")
 		return
@@ -23,7 +23,7 @@ func TestValidGetAhasSentinelParams(t *testing.T) {
 		t.Fatalf("new requirement err: %v", e)
 	}
 	r = append(r, *requirement)
-	params, e := getAhasSentinelParams(r)
+	params, e := getAhasSentinelParams(r, "")
 	if e == nil && params.AppName == "sentinel-console" {
 		t.Logf("Pass TestValidGetAhasSentinelParams")
 	} else {

--- a/pkg/metrics/ahas/k8s_helper.go
+++ b/pkg/metrics/ahas/k8s_helper.go
@@ -1,0 +1,79 @@
+package ahas
+
+import (
+	"errors"
+	"io/ioutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	log "k8s.io/klog"
+	"os"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const K8S_NAMESPACE_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+const AHAS_APP_NAME_ANNOTATION_KEY = "ahasAppName"
+const AHAS_NAMESPACE_ANNOTATION_KEY = "ahasNamespace"
+
+var k8sClient = getK8sClient()
+
+type SentinelPilotMetadata struct {
+	appName   string
+	namespace string
+}
+
+// get a clientset with in-cluster config.
+func getK8sClient() *kubernetes.Clientset {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		log.Error(err)
+		return nil
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		log.Error(err)
+	}
+	return clientset
+}
+
+func getCurrentK8sNamespace() (string, error) {
+	f, err := os.Open(K8S_NAMESPACE_PATH)
+	if err != nil {
+		return "", err
+	}
+	bytes, err := ioutil.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+func getPilotAnnotationMetadata(namespace string) (*SentinelPilotMetadata, error) {
+	println(len(namespace))
+	if len(namespace) == 0 {
+		return nil, errors.New("invalid namespace")
+	}
+	// log.Infoln("Namespace resolved:" + namespace)
+	ds, err := k8sClient.AppsV1().Deployments(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	// log.Infof("Deployment resolved, number: %d\n", len(ds.Items))
+	pilotMetadata := &SentinelPilotMetadata{}
+	for _, deployment := range ds.Items {
+		if len(pilotMetadata.appName) > 0 {
+			break
+		}
+		metaAnnotations := deployment.Spec.Template.ObjectMeta.Annotations
+		for k, v := range metaAnnotations {
+			// log.Infof("Annotation resolved, deployment: %s, k: %s, v: %s\n", deployment.Name, k, v)
+			if k == AHAS_APP_NAME_ANNOTATION_KEY {
+				pilotMetadata.appName = v
+			} else if k == AHAS_NAMESPACE_ANNOTATION_KEY {
+				pilotMetadata.namespace = v
+			}
+		}
+	}
+	return pilotMetadata, nil
+}

--- a/pkg/metrics/cms/workload_metrics.go
+++ b/pkg/metrics/cms/workload_metrics.go
@@ -133,7 +133,7 @@ func getCMSParams(namespace string, requirements labels.Requirements) (params *C
 }
 
 // get group id from meta
-func (cs *CMSMetricSource) getGroupIdByName(params *CMSMetricParams) (groupId int, err error) {
+func (cs *CMSMetricSource) getGroupIdByName(params *CMSMetricParams) (groupId int64, err error) {
 
 	//generate cms GroupName
 	groupName := fmt.Sprintf("k8s-%s-%s-%s-%s", params.ClusterId, params.Namespace, params.WorkloadType, params.WorkloadName)
@@ -164,7 +164,7 @@ func (cs *CMSMetricSource) getGroupIdByName(params *CMSMetricParams) (groupId in
 	return 0, err
 }
 
-func (cs *CMSMetricSource) getMetricListByGroupId(params *CMSMetricParams, groupId int, metricName string) (values []DataPoint, err error) {
+func (cs *CMSMetricSource) getMetricListByGroupId(params *CMSMetricParams, groupId int64, metricName string) (values []DataPoint, err error) {
 	request := cms.CreateDescribeMetricListRequest()
 	request.Scheme = "https"
 


### PR DESCRIPTION
- Polish AHAS Sentinel OpenAPI and adapt to changes in metric adapters
- Support retrieving `appName` and `namespace` from the annotation of target Deployment automatically if AHAS Sentinel pilot is installed.
- Add doc link and example (with AHAS Sentinel pilot).

Note that the `vendor` dir is not updated as it contains large changes. Plz help me to update it.