### PR TITLE
Add support for metric query offset in AHAS Sentinel adapter

### DIFF
--- a/pkg/metrics/ahas/ahas_sentinel_test.go
+++ b/pkg/metrics/ahas/ahas_sentinel_test.go
@@ -18,7 +18,7 @@ func TestInvalidGetAhasSentinelParams(t *testing.T) {
 
 func TestValidGetAhasSentinelParams(t *testing.T) {
 	r := make([]labels.Requirement, 0)
-	requirement, e := labels.NewRequirement(AHAS_SENTINEL_APP_NAME, "=", []string{"sentinel-console"})
+	requirement, e := labels.NewRequirement(SentinelAppNameKey, "=", []string{"sentinel-console"})
 	if e != nil {
 		t.Fatalf("new requirement err: %v", e)
 	}


### PR DESCRIPTION
Add support for metric query offset in AHAS Sentinel adapter (e.g. query range=`[now-interval-offset, now-offset]`), which is intended to avoid inaccurate "delayed" metric data. By default the offset is 10s.